### PR TITLE
Search with exact match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 *   feat(core): search with exact match
 *   fix(core): do not load config when connection pool is provided
 *   fix(core): error when migrating with numerical version
+*   fix(core): `TrailsManager.get()` does not return id
 
 ### 2018-05-21 / 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 2019-05-24 / 1.1.0
+
+*   feat(core): search with exact match
+*   fix(core): do not load config when connection pool is provided
+*   fix(core): error when migrating with numerical version
+
 ### 2018-05-21 / 1.0.0
 
 *   Initial version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-### 2019-05-24 / 1.1.0
+### 2019-05-24 / 2.0.0
 
+*   feat(core): **Breaking** remove the undocumented `config` property of `TrailsManager` instances
 *   feat(core): search with exact match
 *   fix(core): do not load config when connection pool is provided
 *   fix(core): error when migrating with numerical version

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Before running tests, ensure a valid Postgres database is running. The simplest 
 
 ```
 docker-compose up -d
+npm run pg:test:init
 ```
 
 This will start a Postgres database. Running test or coverage runs will automatically populate the database with the information it needs.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nearform/trail",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Audit trail logging service",
   "license": "MIT",
   "author": "nearForm Ltd",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nearform/trail",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Audit trail logging service",
   "license": "MIT",
   "author": "nearForm Ltd",

--- a/packages/trail-core/database/config.js
+++ b/packages/trail-core/database/config.js
@@ -7,7 +7,7 @@ const minimist = require('minimist')
 
 module.exports = function () {
   const argv = minimist(process.argv.slice(2))
-  const version = argv.version
+  const version = '' + argv.version
   const host = argv.host || config.get('db.host')
   const port = argv.port || config.get('db.port')
   const database = argv.database || config.get('db.database')

--- a/packages/trail-core/database/config.js
+++ b/packages/trail-core/database/config.js
@@ -7,7 +7,7 @@ const minimist = require('minimist')
 
 module.exports = function () {
   const argv = minimist(process.argv.slice(2))
-  const version = '' + argv.version
+  const version = (argv.version || '').toString()
   const host = argv.host || config.get('db.host')
   const port = argv.port || config.get('db.port')
   const database = argv.database || config.get('db.database')

--- a/packages/trail-core/lib/index.js
+++ b/packages/trail-core/lib/index.js
@@ -171,6 +171,7 @@ class TrailsManager {
   async get (id) {
     const sql = SQL`
       SELECT
+          id::int,
           timezone('UTC', "when") as "when",
           who_id, what_id, subject_id,
           who_data as who, what_data as what, subject_data as subject,


### PR DESCRIPTION
#### What's in there?

While using the (very well working) Trails Manager on a client project, we faced 2 small issues:
- Searches always use wild-cards. 
  Our UI needs exact matches.

- Even when we provide a Postgres connection, `TrailsManager` constructor still tries to load config.
  We're using dot-env files, it would be a pity to provide config files just for audit trails.
  There's a workaround, but it's not super clean:
  ```js
  module.exports = class TrailDataSource extends TrailsManager {
    constructor(pool) {
      // TrailsManager uses config(), even if we're providing the connection pool
      // Relaxes its validation to avoid console warnings
      process.env.SUPPRESS_NO_CONFIG_WARNING = true
      const env = process.env.NODE_ENV
      delete process.env.NODE_ENV
      super(null, pool)
      process.env.NODE_ENV = env
    }
  ```

- Fix `TrailsManager.get()` to return id along with trail.

Finally, while applying README instructions on how to migrate database, it turned out `minimist` is casting version to a number, which makes postgrator failing ([it expects a string](https://github.com/rickbergfalk/postgrator/blob/master/postgrator.js#L264))