### PR TITLE
Search with case insensitiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-### 2019-05-24 / 2.0.0
+### 2019-06-01 / 2.0.0
 
 *   feat(core): **Breaking** remove the undocumented `config` property of `TrailsManager` instances
 *   feat(core): search with exact match
+*   feat(core): search with case insensitiveness
 *   fix(core): do not load config when connection pool is provided
 *   fix(core): error when migrating with numerical version
 *   fix(core): `TrailsManager.get()` does not return id

--- a/packages/trail-core/README.md
+++ b/packages/trail-core/README.md
@@ -73,13 +73,15 @@ Deletes a trail from the database.
 
 Returns `true` if the record was found and deleted, `false` otherwise.
 
-### `async TrailsManager.search({from, to, who, what, subject, page, pageSize, sort})`
+### `async TrailsManager.search({from, to, who, what, subject, page, pageSize, sort, exactMatch})`
 
 Searchs for trails in the database.
 
 The `from` and `to` attributes follow the same rule of the `when` trail attributes and are inclusive.
 
 The `who`, `what` and `subject` attributes must be string and can be used to search inside the `id` attributes of the respective trail attributes.
+You can use `exactMatch` (default to `false`) to match only trails which `id` is exactly the searched value.
+You can use `caseInsensitive` (default to `false`) to ignore case when matching values.
 
 The `page` and `pageSize` attributes can be used to control pagination. They must be positive numbers. The default pageSize is 25.
 

--- a/packages/trail-core/lib/index.js
+++ b/packages/trail-core/lib/index.js
@@ -60,7 +60,7 @@ class TrailsManager {
     }
   }
 
-  async search ({from, to, who, what, subject, page, pageSize, sort, exactMatch = false} = {}) {
+  async search ({from, to, who, what, subject, page, pageSize, sort, exactMatch = false, caseInsensitive = false} = {}) {
     // Validate parameters
     if (!from) throw new Error('You must specify a starting date ("from" attribute) when querying trails.')
     if (!to) throw new Error('You must specify a ending date ("to" attribute) when querying trails.')
@@ -89,9 +89,10 @@ class TrailsManager {
           ("when" >= ${from.toISO()} AND "when" <= ${to.toISO()})
     `
 
-    if (who) sql.append(SQL` AND who_id LIKE ${exactMatch ? who : '%' + who + '%'}`)
-    if (what) sql.append(SQL` AND what_id LIKE ${exactMatch ? what : '%' + what + '%'}`)
-    if (subject) sql.append(SQL` AND subject_id LIKE ${exactMatch ? subject : '%' + subject + '%'}`)
+    const op = caseInsensitive ? 'ILIKE' : 'LIKE'
+    if (who) sql.append(SQL([` AND who_id ${op} `])).append(SQL`${exactMatch ? who : '%' + who + '%'}`)
+    if (what) sql.append(SQL([` AND what_id ${op} `])).append(SQL`${exactMatch ? what : '%' + what + '%'}`)
+    if (subject) sql.append(SQL([` AND subject_id ${op} `])).append(SQL`${exactMatch ? subject : '%' + subject + '%'}`)
 
     const footer = ` ORDER BY ${sortKey} ${sortAsc ? 'ASC' : 'DESC'} LIMIT ${pageSize} OFFSET ${(page - 1) * pageSize}`
     sql.append(SQL([footer]))

--- a/packages/trail-core/test/index.test.js
+++ b/packages/trail-core/test/index.test.js
@@ -161,6 +161,34 @@ describe('TrailsManager', () => {
         .to.reject(Error, 'Only "id", "when", "who", "what" and "subject" are supported for sorting.')
     })
 
+    test('should return the records with case insensitiveness', async () => {
+      await this.subject.performDatabaseOperations(client => client.query('TRUNCATE trails'))
+
+      const records = [
+        {when: '2018-01-01T12:34:56+00:00', who: 'dog cat fish', what: 'open MORNing', subject: 'window'},
+        {when: '2018-01-02T12:34:56+00:00', who: 'dog cat shark', what: 'evening', subject: 'window'},
+        {when: '2018-01-03T12:34:56+00:00', who: 'wolf cat whale', what: 'open morning', subject: 'door'},
+        {when: '2018-01-04T12:34:56+00:00', who: 'hyena lion fish', what: 'evening', subject: 'DOOr'},
+        {when: '2018-01-05T12:34:56+00:00', who: 'hyena tiger whal', what: 'close night', subject: 'world'}
+      ]
+
+      const ids = await Promise.all(records.map(r => this.subject.insert(r)))
+
+      expect((await this.subject.search({from: '2018-01-01T15:00:00+00:00', to: '2018-01-04T13:34:56+00:00', subject: 'DOOr', sort: 'when', exactMatch: true, caseInsensitive: true}))
+        .map(r => r.id)).to.equal([ids[2], ids[3]])
+
+      expect((await this.subject.search({from: '2018-01-01T15:00:00+00:00', to: '2018-01-04T13:34:56+00:00', subject: 'DOOr', sort: 'when', exactMatch: true}))
+        .map(r => r.id)).to.equal([ids[3]])
+
+      expect((await this.subject.search({from: '2018-01-01T12:00:00+00:00', to: '2018-01-05T13:34:56+00:00', what: 'MORNing', sort: 'when', caseInsensitive: true}))
+        .map(r => r.id)).to.equal([ids[0], ids[2]])
+
+      expect((await this.subject.search({from: '2018-01-01T12:00:00+00:00', to: '2018-01-05T13:34:56+00:00', what: 'MORNing', sort: 'when'}))
+        .map(r => r.id)).to.equal([ids[0]])
+
+      await Promise.all(ids.map(i => this.subject.delete(i)))
+    })
+
     test('should sanitize pagination parameters', async () => {
       const spy = sinon.spy(this.subject, 'performDatabaseOperations')
 


### PR DESCRIPTION
#### What's in there?

As for #11, we would like so search for values regardless of their case.
This adds 
- a new `caseInsensitive` option to `search()` method (default behave as it used to).
- documentation
- changelog update (version 2 wasn't released yet)

#### Notes to reviewers

Writing
```js
const op = caseInsensitive ? 'ILIKE' : 'LIKE'
if (who) sql.append(SQL` AND who_id ${op} ${exactMatch ? who : '%' + who + '%'}`)
```
Does not work, because op is treated as a parameter and escaped, leading to incorrect query (error is: `syntax error at or near "$3"`)

Unfortunately, the `.append()` method of our SQLStatements object does not allow plain strings (as opposed to [this library](https://github.com/felixfbecker/node-sql-template-strings#building-complex-queries-with-append)), leading to this convoluted syntax:
```js
if (who) sql.append(SQL([` AND who_id ${op} `])).append(SQL`${exactMatch ? who : '%' + who + '%'}`)
```
