### PR TITLE
Fix docsify includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,132 +1,20 @@
 # Trail
 
-[![travis][travis-badge]][travis-url]
+[![travis][travis-badge]](https://travis-ci.org/nearform/trail)
 
-Trail is an audit trail log service. It supports logging all kind of actions with a flexible model scheme.
+Trail is a modular and flexible **audit trail log service**. 
 
-For information about the model scheme, see the [trail-core package README][trail-core-readme].
-This repository is home to Trail's three main modules:
+## Features
 
-| Module                                           | Package                                                      |
-| ------------------------------------------------ | ------------------------------------------------------------ |
-| [@nearform/trail-core][trail-core]               | [./packages/trail-core](./packages/trail-core)               |
-| [@nearform/trail-hapi-plugin][trail-hapi-plugin] | [./packages/trail-hapi-plugin](./packages/trail-hapi-plugin) |
-| [@nearform/trail-hapi-server][trail-hapi-server] | [./packages/trail-hapi-server](./packages/trail-hapi-server) |
+-   Run as stand-alone server or extend existing service
+-   **Postgres** backend with **flexible schema**
+-   **REST** and **GraphQL** interfaces
+-   Support for **Fastify** and **Hapi** frameworks
 
-### Node.js support
+## Documentation
 
-Trail requires [Node.js][node] 12.0.0+.
-
-The [Hapi][hapi] plugin and server packages require Hapi 19+.
-
-### Database support
-
-Trail requires an instance of Postgres (version 9.5+) to function correctly. For simplicity, a preconfigured `docker-compose` file has been provided. To run:
-
-    docker-compose up
-
--   **Note:** Ensure you are using the latest version of Docker for (Linux/OSX/Windows)
--   **Note:** Trails needs PostgreSQL >= 9.5
-
-#### Populate the database
-
-The initial tables can be created by executing:
-
-    npm run pg:init
-
-### pgAdmin database access
-
-As the Postgresql docker container has its 5432 port forwarded on the local machine the database can be accessed with pgAdmin.
-
-To access the database using the pgAdmin you have to fill in also the container IP beside the database names and access credentials. The container IP can be seen with `docker ps`.  Use IP 127.0.0.1 and use postgres as username/password to connect to database server.
-
-### Migrations
-
-We use [`postgrator`][postgrator] for database migrations. You can find the sql files in the [`packages/trail-core/database/migrations`](https://github.com/nearform/trail/tree/master/packages/trail-core/database/migrations) folder. To run the migrations manually:
-
-    node packages/trail-core/database/migrate.js --version=<version>`
-
-**Note:** Running the tests or init commands will automaticaly bring the db to the latest version.
-
-### Swagger API Documentation
-
-The Swagger API documentation can be accessed from trail itself. Simply start the server:
-
-    npm run start
-
-and then go to [`http://localhost:8080/documentation/`][swagger-link]
-
-The Swagger documentation also gives the ability to execute calls to the API and see their results.
-
-### ENV variables to set configuration options
-
-Each package uses a default configuration file and then a environment (the value of the `NODE_ENV` environment variable, with a default of `development`) configuration file.
-
-If you put a file named after the enviroment in the `config` folder of the current working directory, it will be parsed and it will override any existing setting.
-
-To get started, look at the files defined in the `config` folder of each package.
-
-## Testing, benching & linting
-
-Before running tests, ensure a valid Postgres database is running. The simplest way to do this is via Docker. Assuming docker is installed on your machine, in the root folder, run:
-
-    docker-compose up -d
-    npm run pg:test:init
-
-This will start a Postgres database. Running test or coverage runs will automatically populate the database with the information it needs.
-
-**Note:** you can tail the Postgres logs if needed with `docker-compose logs --tail=100 -f`
-
-To run tests:
-
-    npm run test
-
-**Note:** running the tests will output duplicate keys errors in Postgres logs, this is expected, as the error handling of those cases is part of what is tested.
-
-To lint the repository:
-
-    npm run lint
-
-To fix (most) linting issues:
-
-    npm run lint -- --fix
-
-To create coverage reports:
-
-    npm run coverage
-
-## Publishing
-
-This repository contains multiple independently versioned packages and is managed by [Lerna](https://github.com/lerna/lerna).
-
-In order to publish packages that have changed since the last release use the following command:
-
-    lerna publish
-
-Lerna will then prompt you to specify the desired version number for each package, update the `package.json` files for you and publish the packages to npm.
+Full documentation can be found at [https://nearform.github.io/trail/](https://nearform.github.io/trail/) or in the `docs/` folder.
 
 ## License
 
 Copyright nearForm Ltd 2018. Licensed under [MIT][license].
-
-[travis-badge]: https://travis-ci.org/nearform/trail.svg?branch=master
-
-[travis-url]: https://travis-ci.org/nearform/trail
-
-[trail-core]: https://www.npmjs.com/package/@nearform/trail-core
-
-[trail-hapi-plugin]: https://www.npmjs.com/package/trail/@nearform/trail-hapi-plugin
-
-[trail-hapi-server]: https://www.npmjs.com/package/trail/@nearform/trail-hapi-server
-
-[trail-core-readme]: ./packages/trail-core/README.md
-
-[node]: https://nodejs.org/it/
-
-[hapi]: https://hapijs.com/
-
-[postgrator]: https://github.com/rickbergfalk/postgrator
-
-[swagger-link]: http://localhost:8080/documentation/
-
-[license]: ./LICENSE.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,12 +75,12 @@ Once your Trail server is running you can integrate it using REST or GraphQL.
 
 ### REST API
 
-[filename](_rest-api.md ":include")
+[filename](_rest-api.md ':include')
 
 ### GraphQL API
 
-[filename](_graphql-api.md ":include")
+[filename](_graphql-api.md ':include')
 
 ## License
 
-[filename](_license.md ":include")
+[filename](_license.md ':include')

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,6 +18,7 @@
       name: '@nearform/trail',
       repo: 'https://github.com/nearform/trail',
       maxLevel: 3,
+      auto2top: true,
     }
   </script>
   <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>

--- a/docs/trail-fastify-graphql-plugin.md
+++ b/docs/trail-fastify-graphql-plugin.md
@@ -10,7 +10,7 @@ To install via npm:
 
 ### Database setup
 
-[filename](_database.md ":include")
+[filename](_database.md ':include')
 
 ## Usage
 
@@ -43,4 +43,4 @@ The plugin takes the following configuration options:
 
 ## License
 
-[filename](_license.md ":include")
+[filename](_license.md ':include')

--- a/docs/trail-fastify-plugin.md
+++ b/docs/trail-fastify-plugin.md
@@ -10,7 +10,7 @@ To install via npm:
 
 ### Database setup
 
-[filename](_database.md ":include")
+[filename](_database.md ':include')
 
 ## Usage
 
@@ -43,4 +43,4 @@ The plugin takes the following configuration options:
 
 ## License
 
-[filename](_license.md ":include")
+[filename](_license.md ':include')

--- a/docs/trail-fastify-server.md
+++ b/docs/trail-fastify-server.md
@@ -10,7 +10,7 @@ To install via npm:
 
 ### Database setup
 
-[filename](_database.md ":include")
+[filename](_database.md ':include')
 
 ## Usage
 
@@ -53,8 +53,8 @@ Command line options take precedence over environment variables.
     npx trail-fastify-server --httpPort 80
     TRAIL_DB_USERNAME=<username> TRAIL_DB_PASSWORD=<password> npx trail-fastify-server
 
-[filename](_commands.md ":include")
+[filename](_commands.md ':include')
 
 ## License
 
-[filename](_license.md ":include")
+[filename](_license.md ':include')

--- a/docs/trail-hapi-plugin.md
+++ b/docs/trail-hapi-plugin.md
@@ -10,7 +10,7 @@ To install via npm:
 
 ### Database setup
 
-[filename](_database.md ":include")
+[filename](_database.md ':include')
 
 ## Usage
 
@@ -46,4 +46,4 @@ The plugin takes the following configuration options:
 
 ## License
 
-[filename](_license.md ":include")
+[filename](_license.md ':include')

--- a/docs/trail-hapi-server.md
+++ b/docs/trail-hapi-server.md
@@ -10,7 +10,7 @@ To install via npm:
 
 ### Database setup
 
-[filename](_database.md ":include")
+[filename](_database.md ':include')
 
 ## Usage
 
@@ -51,8 +51,8 @@ Command line options take precedence over environment variables.
     npx trail-hapi-server --httpPort 80
     TRAIL_DB_USERNAME=<username> TRAIL_DB_PASSWORD=<password> npx trail-hapi-server
 
-[filename](_commands.md ":include")
+[filename](_commands.md ':include')
 
 ## License
 
-[filename](_license.md ":include")
+[filename](_license.md ':include')


### PR DESCRIPTION
This PR fixes `:include:` statements so that docsify rendered embedded files correctly

I have also updated the root `README.md` to point to the documentation