### PR TITLE
Bugfix: Disable swagger if noRESTAPI

### DIFF
--- a/packages/trail-fastify-server/lib/index.js
+++ b/packages/trail-fastify-server/lib/index.js
@@ -17,11 +17,11 @@ module.exports = async function (options) {
     const startTime = process.hrtime()
 
     const server = fastify()
-    server.register(require('fastify-static'), {
-      root: require('swagger-ui-dist').getAbsoluteFSPath()
-    })
-    server.register(require('./swagger'))
     if (settings.use.restAPI) {
+      server.register(require('fastify-static'), {
+        root: require('swagger-ui-dist').getAbsoluteFSPath()
+      })
+      server.register(require('./swagger'))
       server.register(require('@nearform/trail-fastify-plugin'), { db: settings.db })
     }
     if (settings.use.graphQL) {


### PR DESCRIPTION
- Update the trail-fastify-server/index.js to move swagger middleware init inside the block if RESTAPI is enabled